### PR TITLE
Added feature for matcher syntax to Visual Editor. (#1638)

### DIFF
--- a/static/routing-tree.js
+++ b/static/routing-tree.js
@@ -28,12 +28,11 @@ var tooltip = d3.select("body")
 const promQlRegExp = /\b(?<label>[a-z0-9_]\w*)(?<selector>=~?|![=~])"?(?<value>(?<=")(?:[^\\"]|\\.)*(?=")|\w+[^\s},]+)/gmi;
 
 function parseSearch(searchString) {
-  var labels = searchString.replace(/{|}|\"|\'/g, "").split(",");
-  var o = {};
-  labels.forEach(function(label) {
-    var l = label.trim().split("=");
-    o[l[0]] = l[1];
-  });
+  let o = {};
+  let matchedExpressions;
+  while ((matchedExpressions = promQlRegExp.exec(searchString)) !== null) {
+    o[matchedExpressions[1]] = matchedExpressions[3];
+  }
   return o;
 }
 


### PR DESCRIPTION
* feat: Added matcher syntax support for Alertmanager visual editor. First four examples from here https://prometheus.io/docs/alerting/latest/configuration/#matcher should be fine. The last one has an issue, escaped quotes make regexp test fail.
* fix: parseSearch method behave incorrect for matchers syntax:
It's intended to split string to label\value pairs, but it would split values also if comma is present there. It is legitimate to have comma in values according to matcher value rules listed here https://prometheus.io/docs/alerting/latest/configuration/#matcher
Also it couldn't handle strings properly by ignoring escaped quotes that is produced after new syntax parsing.
